### PR TITLE
Add NoPermission annotation and fix some javadoc messages in CommandData

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,14 +23,14 @@
   ~ SOFTWARE.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>me.mattstudios.utils</groupId>
     <artifactId>matt-framework</artifactId>
-    <version>1.3</version>
+    <version>1.3.</version>
     <packaging>jar</packaging>
 
     <name>Matt's Framework</name>
@@ -181,14 +181,14 @@
                 </executions>
             </plugin>
             <!-- COMMENT BEFORE RELEASE -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.3.1</version>
-                <configuration>
-                    <outputDirectory>T:/servers/spigot-1.15/plugins</outputDirectory>
-                </configuration>
-            </plugin>
+            <!--                        <plugin>-->
+            <!--                            <groupId>org.apache.maven.plugins</groupId>-->
+            <!--                            <artifactId>maven-jar-plugin</artifactId>-->
+            <!--                            <version>2.3.1</version>-->
+            <!--                            <configuration>-->
+            <!--                                <outputDirectory>T:/servers/spigot-1.15/plugins</outputDirectory>-->
+            <!--                            </configuration>-->
+            <!--                        </plugin>-->
         </plugins>
         <resources>
             <resource>

--- a/pom.xml
+++ b/pom.xml
@@ -181,14 +181,14 @@
                 </executions>
             </plugin>
             <!-- COMMENT BEFORE RELEASE -->
-            <!--                        <plugin>-->
-            <!--                            <groupId>org.apache.maven.plugins</groupId>-->
-            <!--                            <artifactId>maven-jar-plugin</artifactId>-->
-            <!--                            <version>2.3.1</version>-->
-            <!--                            <configuration>-->
-            <!--                                <outputDirectory>T:/servers/spigot-1.15/plugins</outputDirectory>-->
-            <!--                            </configuration>-->
-            <!--                        </plugin>-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.3.1</version>
+                <configuration>
+                    <outputDirectory>T:/servers/spigot-1.15/plugins</outputDirectory>
+                </configuration>
+            </plugin>
         </plugins>
         <resources>
             <resource>

--- a/src/main/java/me/mattstudios/mf/annotations/NoPermission.java
+++ b/src/main/java/me/mattstudios/mf/annotations/NoPermission.java
@@ -1,0 +1,12 @@
+package me.mattstudios.mf.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface NoPermission {
+    String value();
+}

--- a/src/main/java/me/mattstudios/mf/annotations/Permission.java
+++ b/src/main/java/me/mattstudios/mf/annotations/Permission.java
@@ -29,6 +29,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotate a method with this annotation to add a required permission
+ *
+ * @see NoPermission NoPermission Annotation to change the no permission message
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Permission {

--- a/src/main/java/me/mattstudios/mf/base/CommandBase.java
+++ b/src/main/java/me/mattstudios/mf/base/CommandBase.java
@@ -35,30 +35,20 @@ public abstract class CommandBase {
 
     // The map containing the arguments, for error handling
     private final Map<String, String> arguments = new HashMap<>();
-
-    // The message handler
-    private MessageHandler messageHandler;
-
     // The mutable list with aliases that can be altered any time
     private final List<String> aliases = new ArrayList<>();
+    // The message handler
+    private MessageHandler messageHandler;
 
     // Method that'll run on the registering of the command
     public void onRegister() {
     }
 
     /**
-     * Sets the alias list for the method
-     *
-     * @param aliases The list new aliases to register
-     */
-    public void setAliases(final List<String> aliases) {
-        this.aliases.addAll(aliases);
-    }
-
-    /**
      * Gets the argument used for the command
      *
      * @param name The argument name
+     * @return The argument
      */
     @SuppressWarnings("WeakerAccess")
     public String getArgument(final String name) {
@@ -108,6 +98,15 @@ public abstract class CommandBase {
      */
     List<String> getAliases() {
         return aliases;
+    }
+
+    /**
+     * Sets the alias list for the method
+     *
+     * @param aliases The list new aliases to register
+     */
+    public void setAliases(final List<String> aliases) {
+        this.aliases.addAll(aliases);
     }
 
 }

--- a/src/main/java/me/mattstudios/mf/base/CommandHandler.java
+++ b/src/main/java/me/mattstudios/mf/base/CommandHandler.java
@@ -25,15 +25,8 @@
 package me.mattstudios.mf.base;
 
 
-import me.mattstudios.mf.annotations.Alias;
-import me.mattstudios.mf.annotations.CompleteFor;
-import me.mattstudios.mf.annotations.Completion;
-import me.mattstudios.mf.annotations.Default;
 import me.mattstudios.mf.annotations.Optional;
-import me.mattstudios.mf.annotations.Permission;
-import me.mattstudios.mf.annotations.SubCommand;
-import me.mattstudios.mf.annotations.Values;
-import me.mattstudios.mf.annotations.WrongUsage;
+import me.mattstudios.mf.annotations.*;
 import me.mattstudios.mf.base.components.CommandData;
 import me.mattstudios.mf.exceptions.MfException;
 import org.bukkit.command.Command;
@@ -41,18 +34,8 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.Parameter;
-import java.lang.reflect.ParameterizedType;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.lang.reflect.*;
+import java.util.*;
 
 import static me.mattstudios.mf.base.components.MfUtil.color;
 
@@ -165,7 +148,7 @@ public final class CommandHandler extends Command {
             // Checks if permission annotation is present.
             // Checks whether the command sender has the permission set in the annotation.
             if (subCommand.hasPermissions() && !hasPermissions(sender, subCommand)) {
-                return noPermission(sender);
+                return noPermission(sender, subCommand);
             }
 
             // Checks if the command can be accessed from console
@@ -200,7 +183,7 @@ public final class CommandHandler extends Command {
         // Checks whether the command sender has the permission set in the annotation.
         assert subCommand != null;
         if (subCommand.hasPermissions() && !hasPermissions(sender, subCommand)) {
-            return noPermission(sender);
+            return noPermission(sender, subCommand);
         }
 
         // Checks if the command can be accessed from console
@@ -471,7 +454,7 @@ public final class CommandHandler extends Command {
                 throw new MfException("Method " + method.getName() + " in class " + command.getClass().getName() + " 'String[] args' have to be the last parameter if wants to be used!");
             }
 
-            if (!this.parameterHandler.isRegisteredType(clss)) {
+            if (!parameterHandler.isRegisteredType(clss)) {
                 throw new MfException("Method " + method.getName() + " in class " + command.getClass().getName() + " contains unregistered parameter types!");
             }
 
@@ -494,7 +477,11 @@ public final class CommandHandler extends Command {
         for (final String permission : method.getAnnotation(Permission.class).value()) {
             subCommand.addPermission(permission);
         }
+        // Checks if NoPermission annotation is present.
+        if (!method.isAnnotationPresent(NoPermission.class)) return;
 
+        // Set the no permission to the annotation value
+        subCommand.setNoPermission(method.getAnnotation(NoPermission.class).value());
     }
 
     /**
@@ -507,7 +494,7 @@ public final class CommandHandler extends Command {
         // Checks if WrongUsage annotation is present.
         if (!method.isAnnotationPresent(WrongUsage.class)) return;
 
-        // Checks whether the command sender has the permission set in the annotation.
+        // Set the wrong usage to the annotation value
         subCommand.setWrongUsage(method.getAnnotation(WrongUsage.class).value());
     }
 
@@ -695,8 +682,23 @@ public final class CommandHandler extends Command {
      * @param sender The sender
      * @return Returns true
      */
-    private boolean noPermission(final CommandSender sender) {
-        messageHandler.sendMessage("cmd.no.permission", sender);
+    private boolean noPermission(final CommandSender sender, final CommandData subCommand) {
+//        messageHandler.sendMessage("cmd.no.permission", sender);
+//        return true;
+        final String noPermission = subCommand.getNoPermission();
+
+        if (noPermission == null) {
+            messageHandler.sendMessage("cmd.no.permission", sender);
+            return true;
+        }
+
+        if (!noPermission.startsWith("#") || !messageHandler.hasId(noPermission)) {
+            messageHandler.sendMessage("cmd.no.permission", sender);
+            sender.sendMessage(color(subCommand.getNoPermission()));
+            return true;
+        }
+
+        messageHandler.sendMessage(noPermission, sender);
         return true;
     }
 

--- a/src/main/java/me/mattstudios/mf/base/CommandHandler.java
+++ b/src/main/java/me/mattstudios/mf/base/CommandHandler.java
@@ -683,8 +683,6 @@ public final class CommandHandler extends Command {
      * @return Returns true
      */
     private boolean noPermission(final CommandSender sender, final CommandData subCommand) {
-//        messageHandler.sendMessage("cmd.no.permission", sender);
-//        return true;
         final String noPermission = subCommand.getNoPermission();
 
         if (noPermission == null) {

--- a/src/main/java/me/mattstudios/mf/base/components/CommandData.java
+++ b/src/main/java/me/mattstudios/mf/base/components/CommandData.java
@@ -37,18 +37,6 @@ public final class CommandData {
 
     // Base
     private final CommandBase commandBase;
-
-    // Method
-    private Method method;
-    // The sub command name
-    private String name;
-
-    // If the method is a default one or not
-    private boolean defaultCmd;
-
-    // First parameter of the method.
-    private Class<?> senderClass;
-
     // The list with the other parameters.
     private final List<Class<?>> params = new ArrayList<>();
     // List of parameter names
@@ -59,7 +47,14 @@ public final class CommandData {
     private final List<Integer> valuesArgs = new ArrayList<>();
     // List of the completions.
     private final Map<Integer, String> completions = new HashMap<>();
-
+    // Method
+    private Method method;
+    // The sub command name
+    private String name;
+    // If the method is a default one or not
+    private boolean defaultCmd;
+    // First parameter of the method.
+    private Class<?> senderClass;
     // Secondary tab completion
     private Method completionMethod;
 
@@ -67,6 +62,8 @@ public final class CommandData {
     private boolean optional;
     // Wrong usage message
     private String wrongUsage;
+    // No permission message
+    private String noPermission;
 
     /**
      * Constructor for the command data object
@@ -75,42 +72,6 @@ public final class CommandData {
      */
     public CommandData(final CommandBase commandBase) {
         this.commandBase = commandBase;
-    }
-
-    /**
-     * Sets the sub command name
-     *
-     * @param name The name to set
-     */
-    public void setName(final String name) {
-        this.name = name;
-    }
-
-    /**
-     * Sets the method of the command
-     *
-     * @param method The method
-     */
-    public void setMethod(final Method method) {
-        this.method = method;
-    }
-
-    /**
-     * Sets the command as default
-     *
-     * @param defaultCmd The value to set
-     */
-    public void setDefault(final boolean defaultCmd) {
-        this.defaultCmd = defaultCmd;
-    }
-
-    /**
-     * Sets the first parameter class
-     *
-     * @param senderClass The first parameter
-     */
-    public void setSenderClass(final Class<?> senderClass) {
-        this.senderClass = senderClass;
     }
 
     /**
@@ -132,30 +93,21 @@ public final class CommandData {
     }
 
     /**
-     * Sets the wrong usage message or id
-     *
-     * @param wrongUsage The wrong usage to set
-     */
-    public void setWrongUsage(final String wrongUsage) {
-        this.wrongUsage = wrongUsage;
-    }
-
-    /**
-     * Sets the completion method to run later
-     *
-     * @param completionMethod The completion method
-     */
-    public void setCompletionMethod(final Method completionMethod) {
-        this.completionMethod = completionMethod;
-    }
-
-    /**
      * Gets the sub command name
      *
      * @return The sub command name
      */
     public String getName() {
         return name;
+    }
+
+    /**
+     * Sets the sub command name
+     *
+     * @param name The name to set
+     */
+    public void setName(final String name) {
+        this.name = name;
     }
 
     /**
@@ -168,12 +120,30 @@ public final class CommandData {
     }
 
     /**
+     * Sets the method of the command
+     *
+     * @param method The method
+     */
+    public void setMethod(final Method method) {
+        this.method = method;
+    }
+
+    /**
      * Gets the first parameter class
      *
      * @return The first parameter class
      */
     public Class<?> getSenderClass() {
         return senderClass;
+    }
+
+    /**
+     * Sets the first parameter class
+     *
+     * @param senderClass The first parameter
+     */
+    public void setSenderClass(final Class<?> senderClass) {
+        this.senderClass = senderClass;
     }
 
     /**
@@ -213,6 +183,33 @@ public final class CommandData {
     }
 
     /**
+     * Sets the wrong usage message or id
+     *
+     * @param wrongUsage The wrong usage to set
+     */
+    public void setWrongUsage(final String wrongUsage) {
+        this.wrongUsage = wrongUsage;
+    }
+
+    /**
+     * Gets the no permission message
+     *
+     * @return The no permission message
+     */
+    public String getNoPermission() {
+        return noPermission;
+    }
+
+    /**
+     * Sets the no permission message or id
+     *
+     * @param noPermission The no permission to set
+     */
+    public void setNoPermission(final String noPermission) {
+        this.noPermission = noPermission;
+    }
+
+    /**
      * Gets the parameter names
      *
      * @return The list of parameter names
@@ -240,6 +237,15 @@ public final class CommandData {
     }
 
     /**
+     * Sets the completion method to run later
+     *
+     * @param completionMethod The completion method
+     */
+    public void setCompletionMethod(final Method completionMethod) {
+        this.completionMethod = completionMethod;
+    }
+
+    /**
      * Gets the arg values
      *
      * @return The List value args
@@ -255,6 +261,15 @@ public final class CommandData {
      */
     public boolean isDefault() {
         return defaultCmd;
+    }
+
+    /**
+     * Sets the command as default
+     *
+     * @param defaultCmd The value to set
+     */
+    public void setDefault(final boolean defaultCmd) {
+        this.defaultCmd = defaultCmd;
     }
 
     /**


### PR DESCRIPTION
This merge request adds a `@NoPermission` annotation, you can use this to set the no permission message (in combination with `@Permission`), it works the same as WrongUsage.

Also fixed some javadoc and comments for those who care.
I also added a link to the NoPermission annotation in the Permission annotation so it shows up in the javadoc